### PR TITLE
Added Style to Sticky Note page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sticky Notes</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div class="page">

--- a/style.css
+++ b/style.css
@@ -1,0 +1,66 @@
+
+body {
+    font-family: Arial; 
+    background-color: #f1f1f1; 
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+  }
+  
+  .container {
+    width: 400px;
+    background-color: #ffffff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); 
+    text-align: center;
+  }
+  
+  h1 {
+    font-family: 'DM Serif Display', cursive; 
+    color: #333333; 
+    margin-bottom: 20px;
+  }
+  
+  .note-input {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  
+  textarea {
+    flex: 1;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 16px;
+    resize: none;
+    height: 50px;
+  }
+  
+  textarea::placeholder {
+    color: #999999;
+  }
+  
+  .add-button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 10px 15px;
+    font-size: 20px;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  
+  .add-button:hover {
+    background-color: #0056b3;
+  }
+  
+  .add-button:active {
+    background-color: #003f8a;
+  }
+  


### PR DESCRIPTION
closes #3 

### Changes Implemented:
- Set `Arial, sans-serif` as the default font for the entire page.
- Centered the content vertically and horizontally using `flexbox`.
- Added a background color of `#f1f1f1` to the page for improved contrast.
- Applied a box-shadow to the content container for a subtle elevated effect.
- Updated the heading to use the `'DM Serif Display', cursive` font with a dark color of `#333`.
- Adjusted spacing and alignment between elements to match the provided reference design.

![image](https://github.com/user-attachments/assets/3490574f-2e86-4e4b-9096-28253e0a9472)
